### PR TITLE
New 'add' flag and allow add and notify from command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,26 @@ Add the installr api token to your tiapp.xml file.
   <property name="installr.api_token">ENTER_INSTALLR_API_TOKEN_HERE</property>
 ~~~
 
-Optional - Set `installr.notify` to true, to notify all the testers that a new build is available.
+Optional - Set `installr.notify` to true, to notify all the testers that a new build is available. You can also list team names separated by commas
 
 ~~~
   <property name="installr.notify" type="bool">true</property>
 ~~~
+OR
+~~~
+  <property name="installr.notify" type="bool">Devs,QA</property>
+~~~
+
+Optional - Set `installr.add` to true, to allow all previous testers access to the new build, but not email them. You can also list team names separated by commas
+
+~~~
+  <property name="installr.add" type="bool">true</property>
+~~~
+OR
+~~~
+  <property name="installr.add" type="bool">PMs,Legal</property>
+~~~
+
 
 Optional - Set `installr.default_testers` email address you want to invite to the latest build. Use comma-space for more than one email address
 
@@ -45,6 +60,12 @@ Set release notes using `--installr-release-notes` flag. For example:
 
 ~~~
 $ ti build -p ios -T dist-adhoc --installr --installr-release-notes='New build with awesome features'
+~~~
+
+You can also set notify and add using `--installr-notify` and `--installr-add` flags. For example:
+
+~~~
+$ ti build -p ios -T dist-adhoc --installr --installr-release-notes='New build' --installr-notify='Devs,QA' --installr-add='Legal'
 ~~~
 
 **If not set, you will be prompted for release notes and notify flag**

--- a/plugin/ti.installr/hooks/tiinstallr.js
+++ b/plugin/ti.installr/hooks/tiinstallr.js
@@ -28,6 +28,14 @@ function configure(data, finished) {
 
     config.releaseNotes = data.cli.argv['installr-release-notes'];
 
+    if( ! config.add ){
+      config.add = data.cli.argv['installr-add'];      
+    }
+
+    if( ! config.notify ){
+      config.notify = data.cli.argv['installr-notify'];      
+    }
+
     if (!config.api_token) {
         logger.error("installr.api_token is missing.");
         return;
@@ -114,6 +122,9 @@ function upload2Installr(data, finished) {
     form.append('qqfile', fs.createReadStream(build_file));
     form.append('releaseNotes', config.releaseNotes);
     form.append('notify', config.notify.toString());
+    if( config.add ){
+      form.append('add', config.add.toString());
+    }
 }
 
 function validate(data) {


### PR DESCRIPTION
New API in installr allows you to silently add users so they don't get an email each time.  notify and add flags can also take team names seperated by commas.