### PR TITLE
Get Installr key from env variable INSTALLR_API_TOKEN by default

### DIFF
--- a/plugin/ti.installr/hooks/tiinstallr.js
+++ b/plugin/ti.installr/hooks/tiinstallr.js
@@ -19,6 +19,7 @@ exports.init = function (_logger, config, cli, appc) {
 
 function configure(data, finished) {
     config = {};
+    config.api_token = process.env.INSTALLR_API_TOKEN;
 
     var keys = _.keys(data.tiapp.properties).filter(function(e) { return e.match("^installr\.");});
 


### PR DESCRIPTION
I'd like to put this in so the Installr API Token lines up with a new Plug-In I am publishing:  https://github.com/jeffbonnes/ti-adp
